### PR TITLE
Update ng-pdfviewer.js

### DIFF
--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -8,9 +8,6 @@
 
 angular.module('ngPDFViewer', []).
 directive('pdfviewer', [ '$parse', function($parse) {
-	var canvas = null;
-	var instance_id = null;
-
 	return {
 		restrict: "E",
 		template: '<canvas></canvas>',
@@ -18,12 +15,14 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			onPageLoad: '&',
 			loadProgress: '&',
 			src: '@',
-			id: '='
+			id: '@'
 		},
 		controller: [ '$scope', function($scope) {
 			$scope.pageNum = 1;
 			$scope.pdfDoc = null;
 			$scope.scale = 1.0;
+			$scope.canvas = null;
+			$scope.instance_id = null;
 
 			$scope.documentProgress = function(progressData) {
 				if ($scope.loadProgress) {
@@ -52,10 +51,10 @@ directive('pdfviewer', [ '$parse', function($parse) {
 				console.log('renderPage ', num);
 				$scope.pdfDoc.getPage(num).then(function(page) {
 					var viewport = page.getViewport($scope.scale);
-					var ctx = canvas.getContext('2d');
+					var ctx = $scope.canvas.getContext('2d');
 
-					canvas.height = viewport.height;
-					canvas.width = viewport.width;
+					$scope.canvas.height = viewport.height;
+					$scope.canvas.width = viewport.width;
 
 					page.render({ canvasContext: ctx, viewport: viewport }).promise.then(
 						function() { 
@@ -77,7 +76,7 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			};
 
 			$scope.$on('pdfviewer.nextPage', function(evt, id) {
-				if (id !== instance_id) {
+				if (id !== $scope.instance_id) {
 					return;
 				}
 
@@ -88,7 +87,7 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			});
 
 			$scope.$on('pdfviewer.prevPage', function(evt, id) {
-				if (id !== instance_id) {
+				if (id !== $scope.instance_id) {
 					return;
 				}
 
@@ -99,7 +98,7 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			});
 
 			$scope.$on('pdfviewer.gotoPage', function(evt, id, page) {
-				if (id !== instance_id) {
+				if (id !== $scope.instance_id) {
 					return;
 				}
 
@@ -110,8 +109,8 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			});
 		} ],
 		link: function(scope, iElement, iAttr) {
-			canvas = iElement.find('canvas')[0];
-			instance_id = iAttr.id;
+			scope.canvas = iElement.find('canvas')[0];
+			$scope.instance_id = iAttr.id;
 
 			iAttr.$observe('src', function(v) {
 				console.log('src attribute changed, new value is', v);


### PR DESCRIPTION
Couple of changes made.  One was to move canvas and instance_id into scope instead of being globally available.  This allows multiple <pdfviewer> elements on a page or partial.  Also changed the scope option for "id" to "@" to allow the "id" attribute to be manipulated by Angular models.
