### PR TITLE
allowed for data URIs in the src of the pdf viewer for dynamic pdf viewing

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -2,10 +2,10 @@
 <html>
 	<head>
 		<meta charset="utf-8">
-		<link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css" rel="stylesheet">
+		<link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/css/bootstrap.min.css" rel="stylesheet">
 		<script src="pdf.compat.js"></script>
 		<script src="pdf.js"></script>
-		<script src="//ajax.googleapis.com/ajax/libs/angularjs/1.0.7/angular.min.js"></script>
+		<script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.0.7/angular.min.js"></script>
 		<script src="ng-pdfviewer.js"></script>
 		<script src="test.js"></script>
 		<title>ng-pdfviewer.js test</title>

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -13,6 +13,7 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
     var width = null;
     var height = null;
     var renderPromise = null;
+    var pageFit = false;
 
         return {
             restrict: "E",
@@ -86,18 +87,36 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
 
                 var scale;
 
-                if(height === null)
+                if (pageFit)
                 {
+                    // First, set according to width
                     scale = width / canvas.width;
-                    canvas.width = width;
-                    canvas.height = width * ratio;
+
+                    // Then, make sure height is not too much
+                    if(scale * canvas.height > height)
+                    {
+                        scale = height / canvas.height;
+                    }
+
+                    canvas.width = width * scale;
+                    canvas.height = height * scale;
                 }
                 else
                 {
-                    scale = height / canvas.height;
-                    canvas.height = height;
-                    canvas.width = height * ratio;
+                    if(height === null)
+                    {
+                        scale = width / canvas.width;
+                        canvas.width = width;
+                        canvas.height = width * ratio;
+                    }
+                    else
+                    {
+                        scale = height / canvas.height;
+                        canvas.height = height;
+                        canvas.width = height * ratio;
+                    }
                 }
+
 
                 ctx.scale(scale, scale);
                 ctx.drawImage(newCanvas, 0, 0);
@@ -177,6 +196,7 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
             link: function(scope, iElement, iAttr) {
                 canvas = iElement.find('canvas')[0];
                 instance_id = iAttr.id;
+                pageFit = iAttr.scale === 'page-fit';
 
             if(typeof iAttr.width !== 'undefined')
             {

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -10,8 +10,9 @@ angular.module('ngPDFViewer', []).
 directive('pdfviewer', [ '$parse', function($parse) {
 	var canvas = null;
 	var instance_id = null;
+	var width = null;
 
-	return {
+            return {
 		restrict: "E",
 		template: '<canvas></canvas>',
 		scope: {
@@ -66,7 +67,7 @@ directive('pdfviewer', [ '$parse', function($parse) {
 			$scope.renderPage = function(num, callback) {
 				console.log('renderPage ', num);
 				$scope.pdfDoc.getPage(num).then(function(page) {
-					var viewport = page.getViewport($scope.scale);
+                    var viewport = page.getViewport(width / page.getViewport(1.0).width);
 					var ctx = canvas.getContext('2d');
 
 					canvas.height = viewport.height;
@@ -127,6 +128,11 @@ directive('pdfviewer', [ '$parse', function($parse) {
 		link: function(scope, iElement, iAttr) {
 			canvas = iElement.find('canvas')[0];
 			instance_id = iAttr.id;
+
+            if(typeof iAttr.width !== 'undefined')
+            {
+                width = parseInt(iAttr.width);
+            }
 
 			iAttr.$observe('src', function(v) {
 				console.log('src attribute changed, new value is', v);

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -1,169 +1,196 @@
 /**
  * @preserve AngularJS PDF viewer directive using pdf.js.
  *
- * https://github.com/akrennmair/ng-pdfviewer 
+ * https://github.com/akrennmair/ng-pdfviewer
  *
  * MIT license
  */
 
 angular.module('ngPDFViewer', []).
-directive('pdfviewer', [ '$parse', function($parse) {
-	var canvas = null;
-	var instance_id = null;
+    directive('pdfviewer', [ '$parse', function($parse) {
+        var canvas = null;
+        var instance_id = null;
+        var width = null;
+        var renderPromise = null;
 
-	return {
-		restrict: "E",
-		template: '<canvas></canvas>',
-		scope: {
-			onPageLoad: '&',
-			loadProgress: '&',
-			src: '@',
-			id: '='
-		},
-		controller: [ '$scope', function($scope) {
-			$scope.pageNum = 1;
-			$scope.pdfDoc = null;
-			$scope.scale = 1.0;
+        return {
+            restrict: "E",
+            template: '<canvas></canvas>',
+            scope: {
+                onPageLoad: '&',
+                loadProgress: '&',
+                src: '@',
+                id: '='
+            },
+            controller: [ '$scope', function($scope) {
+                $scope.pageNum = 1;
+                $scope.pdfDoc = null;
+                $scope.scale = 1.0;
 
-			$scope.documentProgress = function(progressData) {
-				if ($scope.loadProgress) {
-					$scope.loadProgress({state: "loading", loaded: progressData.loaded, total: progressData.total});
-				}
-			};
+                $scope.documentProgress = function(progressData) {
+                    if ($scope.loadProgress) {
+                        $scope.loadProgress({state: "loading", loaded: progressData.loaded, total: progressData.total});
+                    }
+                };
 
-            $scope.convertDataURIToBinary = function (dataURI) {
-                var BASE64_MARKER = ';base64,';
-                var base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
-                var base64 = dataURI.substring(base64Index);
-                var raw = window.atob(base64);
-                var rawLength = raw.length;
-                var array = new Uint8Array(new ArrayBuffer(rawLength));
+                $scope.convertDataURIToBinary = function (dataURI) {
+                    var BASE64_MARKER = ';base64,';
+                    var base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
+                    var base64 = dataURI.substring(base64Index);
+                    var raw = window.atob(base64);
+                    var rawLength = raw.length;
+                    var array = new Uint8Array(new ArrayBuffer(rawLength));
 
-                for(var i = 0; i < rawLength; i++) {
-                    array[i] = raw.charCodeAt(i);
+                    for(var i = 0; i < rawLength; i++) {
+                        array[i] = raw.charCodeAt(i);
+                    }
+                    return array;
+                };
+
+                $scope.loadPDF = function(path) {
+                    if(path !== undefined)
+                    {
+                        var param = path.substr(0,4) !== 'data' ? path : $scope.convertDataURIToBinary(path);
+                        console.log('loadPDF ', path, param);
+                        PDFJS.getDocument(param, null, null, $scope.documentProgress).then(function(_pdfDoc) {
+                            $scope.pdfDoc = _pdfDoc;
+                            $scope.renderPage($scope.pageNum, function(success) {
+                                if ($scope.loadProgress) {
+                                    $scope.loadProgress({state: "finished", loaded: 0, total: 0});
+                                }
+                            });
+                        }, function(message, exception) {
+                            console.log("PDF load error: " + message);
+                            if ($scope.loadProgress) {
+                                $scope.loadProgress({state: "error", loaded: 0, total: 0});
+                            }
+                        });
+                    }
+
+                };
+
+                $scope.renderPage = function(num, callback) {
+                    console.log('renderPage ', num);
+                    $scope.pdfDoc.getPage(num).then(function(page) {
+                        var viewport = page.getViewport(width / page.getViewport(1.0).width);
+                        var ctx = canvas.getContext('2d');
+
+                        canvas.height = viewport.height;
+                        canvas.width = viewport.width;
+
+
+                        if(renderPromise != null)
+                        {
+                            renderPromise.cancel()
+                        }
+
+                        renderPromise = page.render({ canvasContext: ctx, viewport: viewport });
+                        renderPromise.promise.then(
+                            function() {
+                                if (callback) {
+                                    callback(true);
+                                }
+                                $scope.$apply(function() {
+                                    $scope.onPageLoad({ page: $scope.pageNum, total: $scope.pdfDoc.numPages });
+                                });
+                            },
+                            function() {
+                                if (callback) {
+                                    callback(false);
+                                }
+                                console.log('page.render failed');
+                            }
+                        );
+                    });
+                };
+
+                $scope.$on('pdfviewer.nextPage', function(evt, id) {
+                    if (id !== instance_id) {
+                        return;
+                    }
+
+                    if ($scope.pageNum < $scope.pdfDoc.numPages) {
+                        $scope.pageNum++;
+                        $scope.renderPage($scope.pageNum);
+                    }
+                });
+
+                $scope.$on('pdfviewer.prevPage', function(evt, id) {
+                    if (id !== instance_id) {
+                        return;
+                    }
+
+                    if ($scope.pageNum > 1) {
+                        $scope.pageNum--;
+                        $scope.renderPage($scope.pageNum);
+                    }
+                });
+
+                $scope.$on('pdfviewer.gotoPage', function(evt, id, page) {
+                    if (id !== instance_id) {
+                        return;
+                    }
+
+                    if (page >= 1 && page <= $scope.pdfDoc.numPages) {
+                        $scope.pageNum = page;
+                        $scope.renderPage($scope.pageNum);
+                    }
+                });
+            } ],
+            link: function(scope, iElement, iAttr) {
+                canvas = iElement.find('canvas')[0];
+                instance_id = iAttr.id;
+
+                if(typeof iAttr.width !== 'undefined')
+                {
+                    width = parseInt(iAttr.width);
                 }
-                return array;
+
+                iAttr.$observe('width', function(v) {
+                    console.log('width attribute changed, new value is', v);
+                    if(typeof iAttr.width !== 'undefined')
+                    {
+                        width = parseInt(iAttr.width);
+                        scope.loadPDF(scope.src);
+                    }
+                });
+
+                iAttr.$observe('src', function(v) {
+                    console.log('src attribute changed, new value is', v);
+                    if (v !== undefined && v !== null && v !== '') {
+                        scope.pageNum = 1;
+                        scope.loadPDF(scope.src);
+                    }
+                });
+            }
+        };
+    }]).
+    service("PDFViewerService", [ '$rootScope', function($rootScope) {
+
+        var svc = { };
+        svc.nextPage = function() {
+            $rootScope.$broadcast('pdfviewer.nextPage');
+        };
+
+        svc.prevPage = function() {
+            $rootScope.$broadcast('pdfviewer.prevPage');
+        };
+
+        svc.Instance = function(id) {
+            var instance_id = id;
+
+            return {
+                prevPage: function() {
+                    $rootScope.$broadcast('pdfviewer.prevPage', instance_id);
+                },
+                nextPage: function() {
+                    $rootScope.$broadcast('pdfviewer.nextPage', instance_id);
+                },
+                gotoPage: function(page) {
+                    $rootScope.$broadcast('pdfviewer.gotoPage', instance_id, page);
+                }
             };
+        };
 
-			$scope.loadPDF = function(path) {
-                var param = path.substr(0,4) !== 'data' ? path : $scope.convertDataURIToBinary(path);
-                console.log('loadPDF ', path, param);
-				PDFJS.getDocument(param, null, null, $scope.documentProgress).then(function(_pdfDoc) {
-					$scope.pdfDoc = _pdfDoc;
-					$scope.renderPage($scope.pageNum, function(success) {
-						if ($scope.loadProgress) {
-							$scope.loadProgress({state: "finished", loaded: 0, total: 0});
-						}
-					});
-				}, function(message, exception) {
-					console.log("PDF load error: " + message);
-					if ($scope.loadProgress) {
-						$scope.loadProgress({state: "error", loaded: 0, total: 0});
-					}
-				});
-			};
-
-			$scope.renderPage = function(num, callback) {
-				console.log('renderPage ', num);
-				$scope.pdfDoc.getPage(num).then(function(page) {
-					var viewport = page.getViewport($scope.scale);
-					var ctx = canvas.getContext('2d');
-
-					canvas.height = viewport.height;
-					canvas.width = viewport.width;
-
-					page.render({ canvasContext: ctx, viewport: viewport }).then(
-						function() { 
-							if (callback) {
-								callback(true);
-							}
-							$scope.$apply(function() {
-								$scope.onPageLoad({ page: $scope.pageNum, total: $scope.pdfDoc.numPages });
-							});
-						}, 
-						function() {
-							if (callback) {
-								callback(false);
-							}
-							console.log('page.render failed');
-						}
-					);
-				});
-			};
-
-			$scope.$on('pdfviewer.nextPage', function(evt, id) {
-				if (id !== instance_id) {
-					return;
-				}
-
-				if ($scope.pageNum < $scope.pdfDoc.numPages) {
-					$scope.pageNum++;
-					$scope.renderPage($scope.pageNum);
-				}
-			});
-
-			$scope.$on('pdfviewer.prevPage', function(evt, id) {
-				if (id !== instance_id) {
-					return;
-				}
-
-				if ($scope.pageNum > 1) {
-					$scope.pageNum--;
-					$scope.renderPage($scope.pageNum);
-				}
-			});
-
-			$scope.$on('pdfviewer.gotoPage', function(evt, id, page) {
-				if (id !== instance_id) {
-					return;
-				}
-
-				if (page >= 1 && page <= $scope.pdfDoc.numPages) {
-					$scope.pageNum = page;
-					$scope.renderPage($scope.pageNum);
-				}
-			});
-		} ],
-		link: function(scope, iElement, iAttr) {
-			canvas = iElement.find('canvas')[0];
-			instance_id = iAttr.id;
-
-			iAttr.$observe('src', function(v) {
-				console.log('src attribute changed, new value is', v);
-				if (v !== undefined && v !== null && v !== '') {
-					scope.pageNum = 1;
-					scope.loadPDF(scope.src);
-				}
-			});
-		}
-	};
-}]).
-service("PDFViewerService", [ '$rootScope', function($rootScope) {
-
-	var svc = { };
-	svc.nextPage = function() {
-		$rootScope.$broadcast('pdfviewer.nextPage');
-	};
-
-	svc.prevPage = function() {
-		$rootScope.$broadcast('pdfviewer.prevPage');
-	};
-
-	svc.Instance = function(id) {
-		var instance_id = id;
-
-		return {
-			prevPage: function() {
-				$rootScope.$broadcast('pdfviewer.prevPage', instance_id);
-			},
-			nextPage: function() {
-				$rootScope.$broadcast('pdfviewer.nextPage', instance_id);
-			},
-			gotoPage: function(page) {
-				$rootScope.$broadcast('pdfviewer.gotoPage', instance_id, page);
-			}
-		};
-	};
-
-	return svc;
-}]);
+        return svc;
+    }]);

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -72,11 +72,19 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
             };
 
             var ratio = 1;
+            var lastImageData;
 
             $scope.setCanvasSize = function()
             {
                 var ctx = canvas.getContext('2d');
-                var imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                var imageData;
+
+                if(lastImageData) imageData = lastImageData;
+                else
+                {
+                    imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+                    lastImageData = imageData;
+                }
 
                 var newCanvas = document.createElement('canvas');
                 $(newCanvas)
@@ -125,6 +133,7 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
 
             $scope.renderPage = function(num, callback) {
                 console.log('renderPage ', num);
+                lastImageData = null;
                 $scope.pdfDoc.getPage(num).then(function(page) {
 
                     var scaling = width / page.getViewport(1.0).width;
@@ -220,7 +229,11 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
                 console.log('width attribute changed, new value is', v);
                 if(typeof iAttr.width !== 'undefined')
                 {
-                    width = parseInt(iAttr.width);
+                    var newWidth = parseInt(iAttr.width);
+                    if(Math.abs(newWidth - width) < 1) // Only re-render if the difference is at least a pixel.
+                        return;
+
+                    width = newWidth;
 
                     scope.setCanvasSize();
 

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -31,9 +31,24 @@ directive('pdfviewer', [ '$parse', function($parse) {
 				}
 			};
 
+            $scope.convertDataURIToBinary = function (dataURI) {
+                var BASE64_MARKER = ';base64,';
+                var base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
+                var base64 = dataURI.substring(base64Index);
+                var raw = window.atob(base64);
+                var rawLength = raw.length;
+                var array = new Uint8Array(new ArrayBuffer(rawLength));
+
+                for(var i = 0; i < rawLength; i++) {
+                    array[i] = raw.charCodeAt(i);
+                }
+                return array;
+            };
+
 			$scope.loadPDF = function(path) {
-				console.log('loadPDF ', path);
-				PDFJS.getDocument(path, null, null, $scope.documentProgress).then(function(_pdfDoc) {
+                var param = path.substr(0,4) !== 'data' ? path : $scope.convertDataURIToBinary(path);
+                console.log('loadPDF ', path, param);
+				PDFJS.getDocument(param, null, null, $scope.documentProgress).then(function(_pdfDoc) {
 					$scope.pdfDoc = _pdfDoc;
 					$scope.renderPage($scope.pageNum, function(success) {
 						if ($scope.loadProgress) {
@@ -57,7 +72,7 @@ directive('pdfviewer', [ '$parse', function($parse) {
 					canvas.height = viewport.height;
 					canvas.width = viewport.width;
 
-					page.render({ canvasContext: ctx, viewport: viewport }).promise.then(
+					page.render({ canvasContext: ctx, viewport: viewport }).then(
 						function() { 
 							if (callback) {
 								callback(true);

--- a/ng-pdfviewer.js
+++ b/ng-pdfviewer.js
@@ -15,59 +15,59 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
     var renderPromise = null;
     var pageFit = false;
 
-        return {
-            restrict: "E",
-            template: '<canvas></canvas>',
-            scope: {
-                onPageLoad: '&',
-                loadProgress: '&',
-                src: '@',
-                id: '='
-            },
-            controller: [ '$scope', function($scope) {
-                $scope.pageNum = 1;
-                $scope.pdfDoc = null;
-                $scope.scale = 1.0;
+    return {
+        restrict: "E",
+        template: '<canvas></canvas>',
+        scope: {
+            onPageLoad: '&',
+            loadProgress: '&',
+            src: '@',
+            id: '='
+        },
+        controller: [ '$scope', function($scope) {
+            $scope.pageNum = 1;
+            $scope.pdfDoc = null;
+            $scope.scale = 1.0;
 
-                $scope.documentProgress = function(progressData) {
-                    if ($scope.loadProgress) {
-                        $scope.loadProgress({state: "loading", loaded: progressData.loaded, total: progressData.total});
-                    }
-                };
+            $scope.documentProgress = function(progressData) {
+                if ($scope.loadProgress) {
+                    $scope.loadProgress({state: "loading", loaded: progressData.loaded, total: progressData.total});
+                }
+            };
 
-                $scope.convertDataURIToBinary = function (dataURI) {
-                    var BASE64_MARKER = ';base64,';
-                    var base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
-                    var base64 = dataURI.substring(base64Index);
-                    var raw = window.atob(base64);
-                    var rawLength = raw.length;
-                    var array = new Uint8Array(new ArrayBuffer(rawLength));
+            $scope.convertDataURIToBinary = function (dataURI) {
+                var BASE64_MARKER = ';base64,';
+                var base64Index = dataURI.indexOf(BASE64_MARKER) + BASE64_MARKER.length;
+                var base64 = dataURI.substring(base64Index);
+                var raw = window.atob(base64);
+                var rawLength = raw.length;
+                var array = new Uint8Array(new ArrayBuffer(rawLength));
 
-                    for(var i = 0; i < rawLength; i++) {
-                        array[i] = raw.charCodeAt(i);
-                    }
-                    return array;
-                };
+                for(var i = 0; i < rawLength; i++) {
+                    array[i] = raw.charCodeAt(i);
+                }
+                return array;
+            };
 
-                $scope.loadPDF = function(path) {
-                    if(path !== undefined)
-                    {
-                        var param = path.substr(0,4) !== 'data' ? path : $scope.convertDataURIToBinary(path);
-                        console.log('loadPDF ', path, param);
-                        PDFJS.getDocument(param, null, null, $scope.documentProgress).then(function(_pdfDoc) {
-                            $scope.pdfDoc = _pdfDoc;
-                            $scope.renderPage($scope.pageNum, function(success) {
-                                if ($scope.loadProgress) {
-                                    $scope.loadProgress({state: "finished", loaded: 0, total: 0});
-                                }
-                            });
-                        }, function(message, exception) {
-                            console.log("PDF load error: " + message);
+            $scope.loadPDF = function(path) {
+                if(path !== undefined)
+                {
+                    var param = path.substr(0,4) !== 'data' ? path : $scope.convertDataURIToBinary(path);
+                    console.log('loadPDF ', path, param);
+                    PDFJS.getDocument(param, null, null, $scope.documentProgress).then(function(_pdfDoc) {
+                        $scope.pdfDoc = _pdfDoc;
+                        $scope.renderPage($scope.pageNum, function(success) {
                             if ($scope.loadProgress) {
-                                $scope.loadProgress({state: "error", loaded: 0, total: 0});
+                                $scope.loadProgress({state: "finished", loaded: 0, total: 0});
                             }
                         });
-                    }
+                    }, function(message, exception) {
+                        console.log("PDF load error: " + message);
+                        if ($scope.loadProgress) {
+                            $scope.loadProgress({state: "error", loaded: 0, total: 0});
+                        }
+                    });
+                }
 
             };
 
@@ -87,7 +87,7 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
 
                 var scale;
 
-                if (pageFit)
+                if (pageFit && height && width)
                 {
                     // First, set according to width
                     scale = width / canvas.width;
@@ -98,8 +98,8 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
                         scale = height / canvas.height;
                     }
 
-                    canvas.width = width * scale;
-                    canvas.height = height * scale;
+                    canvas.width = canvas.width * scale;
+                    canvas.height = canvas.height * scale;
                 }
                 else
                 {
@@ -126,77 +126,85 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
             $scope.renderPage = function(num, callback) {
                 console.log('renderPage ', num);
                 $scope.pdfDoc.getPage(num).then(function(page) {
-                    var scaling = height ? height / page.getViewport(1.0).height : width / page.getViewport(1.0).width;
+
+                    var scaling = width / page.getViewport(1.0).width;
                     var viewport = page.getViewport(scaling);
+
+                    if(pageFit && viewport.height > height)
+                    {
+                        scaling *= height / viewport.height;
+                        viewport = page.getViewport(scaling);
+                    }
+
                     ratio = viewport.height / viewport.width;
                     var ctx = canvas.getContext('2d');
 
-                        canvas.height = viewport.height;
-                        canvas.width = viewport.width;
+                    canvas.height = viewport.height;
+                    canvas.width = viewport.width;
 
 
-                        if(renderPromise != null)
-                        {
-                            renderPromise.cancel()
-                        }
+                    if(renderPromise != null)
+                    {
+                        renderPromise.cancel()
+                    }
 
-                        renderPromise = page.render({ canvasContext: ctx, viewport: viewport });
-                        renderPromise.promise.then(
-                            function() {
-                                if (callback) {
-                                    callback(true);
-                                }
-                                $scope.$apply(function() {
-                                    $scope.onPageLoad({ page: $scope.pageNum, total: $scope.pdfDoc.numPages });
-                                });
-                            },
-                            function() {
-                                if (callback) {
-                                    callback(false);
-                                }
-                                console.log('page.render failed');
+                    renderPromise = page.render({ canvasContext: ctx, viewport: viewport });
+                    renderPromise.promise.then(
+                        function() {
+                            if (callback) {
+                                callback(true);
                             }
-                        );
-                    });
-                };
-
-                $scope.$on('pdfviewer.nextPage', function(evt, id) {
-                    if (id !== instance_id) {
-                        return;
-                    }
-
-                    if ($scope.pageNum < $scope.pdfDoc.numPages) {
-                        $scope.pageNum++;
-                        $scope.renderPage($scope.pageNum);
-                    }
+                            $scope.$apply(function() {
+                                $scope.onPageLoad({ page: $scope.pageNum, total: $scope.pdfDoc.numPages });
+                            });
+                        },
+                        function() {
+                            if (callback) {
+                                callback(false);
+                            }
+                            console.log('page.render failed');
+                        }
+                    );
                 });
+            };
 
-                $scope.$on('pdfviewer.prevPage', function(evt, id) {
-                    if (id !== instance_id) {
-                        return;
-                    }
+            $scope.$on('pdfviewer.nextPage', function(evt, id) {
+                if (id !== instance_id) {
+                    return;
+                }
 
-                    if ($scope.pageNum > 1) {
-                        $scope.pageNum--;
-                        $scope.renderPage($scope.pageNum);
-                    }
-                });
+                if ($scope.pageNum < $scope.pdfDoc.numPages) {
+                    $scope.pageNum++;
+                    $scope.renderPage($scope.pageNum);
+                }
+            });
 
-                $scope.$on('pdfviewer.gotoPage', function(evt, id, page) {
-                    if (id !== instance_id) {
-                        return;
-                    }
+            $scope.$on('pdfviewer.prevPage', function(evt, id) {
+                if (id !== instance_id) {
+                    return;
+                }
 
-                    if (page >= 1 && page <= $scope.pdfDoc.numPages) {
-                        $scope.pageNum = page;
-                        $scope.renderPage($scope.pageNum);
-                    }
-                });
-            } ],
-            link: function(scope, iElement, iAttr) {
-                canvas = iElement.find('canvas')[0];
-                instance_id = iAttr.id;
-                pageFit = iAttr.scale === 'page-fit';
+                if ($scope.pageNum > 1) {
+                    $scope.pageNum--;
+                    $scope.renderPage($scope.pageNum);
+                }
+            });
+
+            $scope.$on('pdfviewer.gotoPage', function(evt, id, page) {
+                if (id !== instance_id) {
+                    return;
+                }
+
+                if (page >= 1 && page <= $scope.pdfDoc.numPages) {
+                    $scope.pageNum = page;
+                    $scope.renderPage($scope.pageNum);
+                }
+            });
+        } ],
+        link: function(scope, iElement, iAttr) {
+            canvas = iElement.find('canvas')[0];
+            instance_id = iAttr.id;
+            pageFit = iAttr.scale === 'page-fit';
 
             if(typeof iAttr.width !== 'undefined')
             {
@@ -208,11 +216,11 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
 
             var loadPdfTimeout = null;
 
-                iAttr.$observe('width', function(v) {
-                    console.log('width attribute changed, new value is', v);
-                    if(typeof iAttr.width !== 'undefined')
-                    {
-                        width = parseInt(iAttr.width);
+            iAttr.$observe('width', function(v) {
+                console.log('width attribute changed, new value is', v);
+                if(typeof iAttr.width !== 'undefined')
+                {
+                    width = parseInt(iAttr.width);
 
                     scope.setCanvasSize();
 
@@ -229,48 +237,48 @@ directive('pdfviewer', [ '$parse', '$timeout', function($parse, $timeout) {
 
                     scope.setCanvasSize();
 
-                        var loadPdf = function() { scope.loadPDF(scope.src); };
-                        $timeout.cancel(loadPdfTimeout);
-                        loadPdfTimeout = $timeout(loadPdf, 50);
-                    }
-                });
+                    var loadPdf = function() { scope.loadPDF(scope.src); };
+                    $timeout.cancel(loadPdfTimeout);
+                    loadPdfTimeout = $timeout(loadPdf, 50);
+                }
+            });
 
-                iAttr.$observe('src', function(v) {
-                    console.log('src attribute changed, new value is', v);
-                    if (v !== undefined && v !== null && v !== '') {
-                        scope.pageNum = 1;
-                        scope.loadPDF(scope.src);
-                    }
-                });
+            iAttr.$observe('src', function(v) {
+                console.log('src attribute changed, new value is', v);
+                if (v !== undefined && v !== null && v !== '') {
+                    scope.pageNum = 1;
+                    scope.loadPDF(scope.src);
+                }
+            });
+        }
+    };
+}]).
+service("PDFViewerService", [ '$rootScope', function($rootScope) {
+
+    var svc = { };
+    svc.nextPage = function() {
+        $rootScope.$broadcast('pdfviewer.nextPage');
+    };
+
+    svc.prevPage = function() {
+        $rootScope.$broadcast('pdfviewer.prevPage');
+    };
+
+    svc.Instance = function(id) {
+        var instance_id = id;
+
+        return {
+            prevPage: function() {
+                $rootScope.$broadcast('pdfviewer.prevPage', instance_id);
+            },
+            nextPage: function() {
+                $rootScope.$broadcast('pdfviewer.nextPage', instance_id);
+            },
+            gotoPage: function(page) {
+                $rootScope.$broadcast('pdfviewer.gotoPage', instance_id, page);
             }
         };
-    }]).
-    service("PDFViewerService", [ '$rootScope', function($rootScope) {
+    };
 
-        var svc = { };
-        svc.nextPage = function() {
-            $rootScope.$broadcast('pdfviewer.nextPage');
-        };
-
-        svc.prevPage = function() {
-            $rootScope.$broadcast('pdfviewer.prevPage');
-        };
-
-        svc.Instance = function(id) {
-            var instance_id = id;
-
-            return {
-                prevPage: function() {
-                    $rootScope.$broadcast('pdfviewer.prevPage', instance_id);
-                },
-                nextPage: function() {
-                    $rootScope.$broadcast('pdfviewer.nextPage', instance_id);
-                },
-                gotoPage: function(page) {
-                    $rootScope.$broadcast('pdfviewer.gotoPage', instance_id, page);
-                }
-            };
-        };
-
-        return svc;
-    }]);
+    return svc;
+}]);


### PR DESCRIPTION
with this patch, it's possible to use ng-pdfviewer interactively by changing the source of the dom element to different data uris. we can use the dom element like this: 

```
<pdfviewer ng-src="{{pdfContent}}" on-page-load='pageLoaded(page,total)' id="viewer"></pdfviewer>
```

and then feed the data uri into pdfContent. that even allows to use a user selected pdf file to be displayed immediately, using html5 filereader: 

```
$scope.pdfUpload = function(input)
{
    var reader = new FileReader();
    reader.onloadend = function () {
        var data = this.result;
        $scope.$apply(function () { $scope.pdfContent = $sce.trustAsResourceUrl(data); });
    };
    reader.readAsDataURL(input.files[0]);
};
```

with

```
<input type="file" id="file" name="file" ng-model="pdfFile"
    onchange="angular.element(this).scope().pdfUpload(this)" />
```
